### PR TITLE
Changed reference to match tsconfig exclude

### DIFF
--- a/tsd/phaser_box2d.d.ts
+++ b/tsd/phaser_box2d.d.ts
@@ -1,4 +1,4 @@
-﻿/// <reference path="phaser.comments.d.ts" />
+﻿/// <reference path="phaser.d.ts" />
 /// <reference path="box2d.d.ts" />
 
 declare module Phaser {


### PR DESCRIPTION
tsconfig.json excludes phaser.comments.d.ts but reference to phaser.comments.d.ts in phaser_box2d.d.ts will cause this exclude to be ignored. This will result in multiple definition errors because phaser.comments.d.ts and phaser.d.ts will both be used.